### PR TITLE
feat: Scaffold initial Flutter project for App Store frontend

### DIFF
--- a/app_store_frontend/.env
+++ b/app_store_frontend/.env
@@ -1,0 +1,1 @@
+API_BASE_URL=http://localhost:8080/api

--- a/app_store_frontend/.env.example
+++ b/app_store_frontend/.env.example
@@ -1,0 +1,1 @@
+API_BASE_URL=http://localhost:8080/api

--- a/app_store_frontend/README.md
+++ b/app_store_frontend/README.md
@@ -1,0 +1,85 @@
+# App Store Frontend
+
+This is the Flutter frontend for the internal app store. It allows users to browse and download Android (APK) and iOS (IPA) apps. Administrators can upload new apps.
+
+## Features
+
+- User and Admin login.
+- View a list of available apps.
+- Download APKs directly.
+- Trigger iOS app installation via `itms-services`.
+- Admin dashboard to upload new apps with metadata.
+- Multipart file upload with a progress bar.
+
+## Tech Stack
+
+- **Framework**: Flutter
+- **State Management**: Riverpod
+- **API Client**: Dio
+- **Environment**: flutter_dotenv
+- **Secure Storage**: flutter_secure_storage (for mobile)
+- **Web Storage**: shared_preferences (for web)
+
+## Project Structure
+
+The project is structured to separate concerns and group files by feature.
+
+```
+lib/
+├── src/
+│   ├── features/
+│   │   ├── auth/ (Login)
+│   │   ├── apps/ (App List)
+│   │   └── admin/ (Admin Dashboard, Upload Form)
+│   ├── models/ (Data models, e.g., App)
+│   ├── services/ (API, Authentication)
+│   └── utils/ (Utilities)
+└── main.dart (App entry point)
+```
+
+## Setup and Configuration
+
+1.  **Install Flutter**: Ensure you have the Flutter SDK installed. Follow the [official documentation](https://flutter.dev/docs/get-started/install) for instructions.
+
+2.  **Clone the repository**:
+    ```bash
+    git clone <repository-url>
+    cd app_store_frontend
+    ```
+
+3.  **Install dependencies**:
+    ```bash
+    flutter pub get
+    ```
+
+4.  **Configure the Backend API**:
+    The frontend needs to know the base URL of the backend server. This is configured using an environment file.
+
+    - Create a file named `.env` in the root of the project.
+    - Add the following line to the file, replacing the URL with your backend's address:
+      ```
+      API_BASE_URL=http://localhost:8080/api
+      ```
+    - A `.env.example` file is provided as a template.
+
+## How to Run
+
+- **Web**:
+  ```bash
+  flutter run -d chrome
+  ```
+- **Mobile (Android/iOS)**:
+  Make sure you have a device connected or an emulator/simulator running.
+  ```bash
+  flutter run
+  ```
+
+## Connecting to the Spring Boot Backend
+
+This frontend is designed to work with a Java Spring Boot backend that exposes the following endpoints:
+
+- `POST /api/auth/login`
+- `GET /api/apps`
+- `POST /api/apps/upload`
+
+Ensure your backend server is running and accessible at the `API_BASE_URL` you configured in the `.env` file. The `api_service.dart` file handles the communication with these endpoints, and `auth_service.dart` manages the JWT token for authenticated requests.

--- a/app_store_frontend/lib/main.dart
+++ b/app_store_frontend/lib/main.dart
@@ -1,0 +1,72 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_dotenv/flutter_dotenv.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:app_store_frontend/src/features/auth/presentation/login_page.dart';
+import 'package:app_store_frontend/src/services/auth_service.dart';
+import 'package:app_store_frontend/src/features/apps/presentation/app_list_page.dart';
+import 'package:app_store_frontend/src/features/admin/presentation/admin_dashboard.dart';
+
+Future<void> main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  await dotenv.load(fileName: ".env");
+  runApp(const ProviderScope(child: MyApp()));
+}
+
+final initialRouteProvider = FutureProvider<String>((ref) async {
+  final authService = ref.watch(authServiceProvider);
+  final token = await authService.getToken();
+  // In a real app, you'd decode the token to get the role
+  // For now, let's assume a token means you're a regular user.
+  // A more robust solution would be needed for role-based routing.
+  if (token != null) {
+    // This is a simplified check. A real app would check the token's validity
+    // and decode it to determine the user's role.
+    // For this example, we'll just check for a "dummy-admin-token".
+    if (token.contains("admin")) { // This is NOT secure, for demo only
+        return '/admin';
+    }
+    return '/apps';
+  }
+  return '/login';
+});
+
+
+class MyApp extends ConsumerWidget {
+  const MyApp({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final initialRoute = ref.watch(initialRouteProvider);
+
+    return MaterialApp(
+      title: 'Internal App Store',
+      theme: ThemeData(
+        primarySwatch: Colors.indigo,
+        visualDensity: VisualDensity.adaptivePlatformDensity,
+      ),
+      home: initialRoute.when(
+        data: (route) => _buildInitialScreen(route),
+        loading: () => const Scaffold(body: Center(child: CircularProgressIndicator())),
+        error: (e, s) => const Scaffold(body: Center(child: Text('Error loading app'))),
+      ),
+      routes: {
+        '/login': (context) => const LoginPage(),
+        '/apps': (context) => const AppListPage(),
+        '/admin': (context) => const AdminDashboard(),
+      },
+    );
+  }
+
+  Widget _buildInitialScreen(String route) {
+    switch (route) {
+      case '/login':
+        return const LoginPage();
+      case '/apps':
+        return const AppListPage();
+      case '/admin':
+        return const AdminDashboard();
+      default:
+        return const LoginPage();
+    }
+  }
+}

--- a/app_store_frontend/lib/src/features/admin/presentation/admin_dashboard.dart
+++ b/app_store_frontend/lib/src/features/admin/presentation/admin_dashboard.dart
@@ -1,0 +1,34 @@
+import 'package:flutter/material.dart';
+import 'package:app_store_frontend/src/features/admin/presentation/upload_form.dart';
+import 'package:app_store_frontend/src/features/apps/presentation/app_list_page.dart';
+
+class AdminDashboard extends StatelessWidget {
+  const AdminDashboard({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return DefaultTabController(
+      length: 2,
+      child: Scaffold(
+        appBar: AppBar(
+          title: const Text('Admin Dashboard'),
+          bottom: const TabBar(
+            tabs: [
+              Tab(text: 'App List'),
+              Tab(text: 'Upload App'),
+            ],
+          ),
+        ),
+        body: const TabBarView(
+          children: [
+            AppListPage(),
+            Padding(
+              padding: EdgeInsets.all(16.0),
+              child: UploadForm(),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/app_store_frontend/lib/src/features/admin/presentation/upload_form.dart
+++ b/app_store_frontend/lib/src/features/admin/presentation/upload_form.dart
@@ -1,0 +1,161 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:file_picker/file_picker.dart';
+import 'package:app_store_frontend/src/services/api_service.dart';
+
+final uploadProvider = StateNotifierProvider<UploadNotifier, UploadState>((ref) {
+  return UploadNotifier(ref.read(apiServiceProvider));
+});
+
+class UploadNotifier extends StateNotifier<UploadState> {
+  final ApiService _apiService;
+
+  UploadNotifier(this._apiService) : super(UploadInitial());
+
+  Future<void> uploadApp({
+    required String name,
+    required String version,
+    required String purpose,
+    required String platform,
+    required String filePath,
+  }) async {
+    try {
+      state = UploadInProgress(0);
+      await _apiService.uploadApp(
+        name: name,
+        version: version,
+        purpose: purpose,
+        platform: platform,
+        filePath: filePath,
+        onSendProgress: (sent, total) {
+          state = UploadInProgress(sent / total);
+        },
+      );
+      state = UploadSuccess();
+    } catch (e) {
+      state = UploadFailure(e.toString());
+    }
+  }
+}
+
+abstract class UploadState {}
+
+class UploadInitial extends UploadState {}
+
+class UploadInProgress extends UploadState {
+  final double progress;
+  UploadInProgress(this.progress);
+}
+
+class UploadSuccess extends UploadState {}
+
+class UploadFailure extends UploadState {
+  final String error;
+  UploadFailure(this.error);
+}
+
+class UploadForm extends ConsumerStatefulWidget {
+  const UploadForm({super.key});
+
+  @override
+  ConsumerState<UploadForm> createState() => _UploadFormState();
+}
+
+class _UploadFormState extends ConsumerState<UploadForm> {
+  final _formKey = GlobalKey<FormState>();
+  final _nameController = TextEditingController();
+  final _versionController = TextEditingController();
+  final _purposeController = TextEditingController();
+  String _platform = 'android';
+  String? _filePath;
+
+  @override
+  Widget build(BuildContext context) {
+    ref.listen<UploadState>(uploadProvider, (previous, next) {
+      if (next is UploadSuccess) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Upload successful!')),
+        );
+        _formKey.currentState?.reset();
+        setState(() {
+          _filePath = null;
+        });
+      } else if (next is UploadFailure) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text(next.error)),
+        );
+      }
+    });
+
+    return Form(
+      key: _formKey,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          TextFormField(
+            controller: _nameController,
+            decoration: const InputDecoration(labelText: 'App Name'),
+            validator: (value) => value!.isEmpty ? 'Required' : null,
+          ),
+          TextFormField(
+            controller: _versionController,
+            decoration: const InputDecoration(labelText: 'Version'),
+            validator: (value) => value!.isEmpty ? 'Required' : null,
+          ),
+          TextFormField(
+            controller: _purposeController,
+            decoration: const InputDecoration(labelText: 'Purpose'),
+            validator: (value) => value!.isEmpty ? 'Required' : null,
+          ),
+          DropdownButtonFormField<String>(
+            value: _platform,
+            items: ['android', 'ios']
+                .map((p) => DropdownMenuItem(value: p, child: Text(p)))
+                .toList(),
+            onChanged: (value) => setState(() => _platform = value!),
+            decoration: const InputDecoration(labelText: 'Platform'),
+          ),
+          const SizedBox(height: 20),
+          Row(
+            children: [
+              ElevatedButton(
+                onPressed: () async {
+                  final result = await FilePicker.platform.pickFiles();
+                  if (result != null) {
+                    setState(() => _filePath = result.files.single.path);
+                  }
+                },
+                child: const Text('Select File'),
+              ),
+              const SizedBox(width: 10),
+              if (_filePath != null) Text(_filePath!),
+            ],
+          ),
+          const SizedBox(height: 20),
+          Consumer(
+            builder: (context, ref, child) {
+              final uploadState = ref.watch(uploadProvider);
+              if (uploadState is UploadInProgress) {
+                return LinearProgressIndicator(value: uploadState.progress);
+              }
+              return ElevatedButton(
+                onPressed: () {
+                  if (_formKey.currentState!.validate() && _filePath != null) {
+                    ref.read(uploadProvider.notifier).uploadApp(
+                          name: _nameController.text,
+                          version: _versionController.text,
+                          purpose: _purposeController.text,
+                          platform: _platform,
+                          filePath: _filePath!,
+                        );
+                  }
+                },
+                child: const Text('Upload'),
+              );
+            },
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/app_store_frontend/lib/src/features/apps/presentation/app_list_page.dart
+++ b/app_store_frontend/lib/src/features/apps/presentation/app_list_page.dart
@@ -1,0 +1,53 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:app_store_frontend/src/models/app_model.dart';
+import 'package:app_store_frontend/src/services/api_service.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+final appListProvider = FutureProvider<List<App>>((ref) async {
+  final apiService = ref.watch(apiServiceProvider);
+  return apiService.getApps();
+});
+
+class AppListPage extends ConsumerWidget {
+  const AppListPage({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final appList = ref.watch(appListProvider);
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Available Apps')),
+      body: appList.when(
+        data: (apps) => ListView.builder(
+          itemCount: apps.length,
+          itemBuilder: (context, index) {
+            final app = apps[index];
+            return ListTile(
+              title: Text(app.name),
+              subtitle: Text('v${app.version} - ${app.purpose}'),
+              trailing: ElevatedButton(
+                onPressed: () => _downloadApp(app),
+                child: const Text('Download'),
+              ),
+            );
+          },
+        ),
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (error, stack) => Center(child: Text('Error: $error')),
+      ),
+    );
+  }
+
+  void _downloadApp(App app) async {
+    final url = app.platform == AppPlatform.ios
+        ? 'itms-services://?action=download-manifest&url=${app.plistUrl}'
+        : app.downloadUrl;
+
+    if (await canLaunchUrl(Uri.parse(url))) {
+      await launchUrl(Uri.parse(url));
+    } else {
+      throw 'Could not launch $url';
+    }
+  }
+}

--- a/app_store_frontend/lib/src/features/auth/presentation/login_page.dart
+++ b/app_store_frontend/lib/src/features/auth/presentation/login_page.dart
@@ -1,0 +1,102 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:app_store_frontend/src/services/api_service.dart';
+import 'package:app_store_frontend/src/services/auth_service.dart';
+import 'package:app_store_frontend/src/features/apps/presentation/app_list_page.dart';
+
+final loginProvider = StateNotifierProvider<LoginNotifier, LoginState>((ref) {
+  return LoginNotifier(ref.read(apiServiceProvider), ref.read(authServiceProvider));
+});
+
+class LoginNotifier extends StateNotifier<LoginState> {
+  final ApiService _apiService;
+  final AuthService _authService;
+
+  LoginNotifier(this._apiService, this._authService) : super(LoginInitial());
+
+  Future<void> login(String username, String password) async {
+    try {
+      state = LoginLoading();
+      final response = await _apiService.login(username, password);
+      final token = response['token'];
+      await _authService.login(token);
+      state = LoginSuccess();
+    } catch (e) {
+      state = LoginFailure(e.toString());
+    }
+  }
+}
+
+abstract class LoginState {}
+
+class LoginInitial extends LoginState {}
+
+class LoginLoading extends LoginState {}
+
+class LoginSuccess extends LoginState {}
+
+class LoginFailure extends LoginState {
+  final String error;
+  LoginFailure(this.error);
+}
+
+class LoginPage extends ConsumerWidget {
+  const LoginPage({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final usernameController = TextEditingController();
+    final passwordController = TextEditingController();
+
+    ref.listen<LoginState>(loginProvider, (previous, next) {
+      if (next is LoginSuccess) {
+        Navigator.of(context).pushReplacement(
+          MaterialPageRoute(builder: (context) => const AppListPage()),
+        );
+      } else if (next is LoginFailure) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text(next.error)),
+        );
+      }
+    });
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Login')),
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            TextField(
+              controller: usernameController,
+              decoration: const InputDecoration(labelText: 'Username'),
+            ),
+            TextField(
+              controller: passwordController,
+              decoration: const InputDecoration(labelText: 'Password'),
+              obscureText: true,
+            ),
+            const SizedBox(height: 20),
+            Consumer(
+              builder: (context, ref, child) {
+                final loginState = ref.watch(loginProvider);
+                if (loginState is LoginLoading) {
+                  return const CircularProgressIndicator();
+                }
+                return ElevatedButton(
+                  onPressed: () {
+                    ref.read(loginProvider.notifier).login(
+                          usernameController.text,
+                          passwordController.text,
+                        );
+                  },
+                  child: const Text('Login'),
+                );
+              },
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/app_store_frontend/lib/src/models/app_model.dart
+++ b/app_store_frontend/lib/src/models/app_model.dart
@@ -1,0 +1,48 @@
+import 'package:flutter/foundation.dart';
+
+enum AppPlatform { android, ios }
+
+class App {
+  final String id;
+  final String name;
+  final String version;
+  final String purpose;
+  final AppPlatform platform;
+  final String downloadUrl;
+  final String? plistUrl;
+
+  App({
+    required this.id,
+    required this.name,
+    required this.version,
+    required this.purpose,
+    required this.platform,
+    required this.downloadUrl,
+    this.plistUrl,
+  });
+
+  factory App.fromJson(Map<String, dynamic> json) {
+    return App(
+      id: json['id'],
+      name: json['name'],
+      version: json['version'],
+      purpose: json['purpose'],
+      platform: (json['platform'] as String).toAppPlatform(),
+      downloadUrl: json['downloadUrl'],
+      plistUrl: json['plistUrl'],
+    );
+  }
+}
+
+extension on String {
+  AppPlatform toAppPlatform() {
+    switch (this) {
+      case 'android':
+        return AppPlatform.android;
+      case 'ios':
+        return AppPlatform.ios;
+      default:
+        throw Exception('Unknown platform: $this');
+    }
+  }
+}

--- a/app_store_frontend/lib/src/services/api_service.dart
+++ b/app_store_frontend/lib/src/services/api_service.dart
@@ -1,0 +1,72 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_dotenv/flutter_dotenv.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:app_store_frontend/src/models/app_model.dart';
+import 'package:app_store_frontend/src/services/auth_service.dart';
+
+final apiServiceProvider = Provider<ApiService>((ref) {
+  final authService = ref.watch(authServiceProvider);
+  return ApiService(authService);
+});
+
+class ApiService {
+  final AuthService _authService;
+  late final Dio _dio;
+
+  ApiService(this._authService) {
+    final options = BaseOptions(
+      baseUrl: dotenv.env['API_BASE_URL']!,
+      connectTimeout: const Duration(milliseconds: 5000),
+      receiveTimeout: const Duration(milliseconds: 3000),
+    );
+    _dio = Dio(options);
+    _dio.interceptors.add(
+      InterceptorsWrapper(
+        onRequest: (options, handler) async {
+          final token = await _authService.getToken();
+          if (token != null) {
+            options.headers['Authorization'] = 'Bearer $token';
+          }
+          return handler.next(options);
+        },
+      ),
+    );
+  }
+
+  Future<Map<String, dynamic>> login(String username, String password) async {
+    final response = await _dio.post(
+      '/auth/login',
+      data: {'username': username, 'password': password},
+    );
+    return response.data;
+  }
+
+  Future<List<App>> getApps() async {
+    final response = await _dio.get('/apps');
+    final data = response.data as List;
+    return data.map((json) => App.fromJson(json)).toList();
+  }
+
+  Future<void> uploadApp({
+    required String name,
+    required String version,
+    required String purpose,
+    required String platform,
+    required String filePath,
+    required Function(int, int) onSendProgress,
+  }) async {
+    final formData = FormData.fromMap({
+      'name': name,
+      'version': version,
+      'purpose': purpose,
+      'platform': platform,
+      'file': await MultipartFile.fromFile(filePath),
+    });
+
+    await _dio.post(
+      '/apps/upload',
+      data: formData,
+      onSendProgress: onSendProgress,
+    );
+  }
+}

--- a/app_store_frontend/lib/src/services/auth_service.dart
+++ b/app_store_frontend/lib/src/services/auth_service.dart
@@ -1,0 +1,42 @@
+import 'package:flutter/foundation.dart' show kIsWeb;
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+final authServiceProvider = Provider<AuthService>((ref) => AuthService());
+
+class AuthService {
+  final _storage = kIsWeb ? null : const FlutterSecureStorage();
+  static const _tokenKey = 'jwt_token';
+
+  Future<void> login(String token) async {
+    await _saveToken(token);
+  }
+
+  Future<void> logout() async {
+    if (kIsWeb) {
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.remove(_tokenKey);
+    } else {
+      await _storage?.delete(key: _tokenKey);
+    }
+  }
+
+  Future<String?> getToken() async {
+    if (kIsWeb) {
+      final prefs = await SharedPreferences.getInstance();
+      return prefs.getString(_tokenKey);
+    } else {
+      return await _storage?.read(key: _tokenKey);
+    }
+  }
+
+  Future<void> _saveToken(String token) async {
+    if (kIsWeb) {
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setString(_tokenKey, token);
+    } else {
+      await _storage?.write(key: _tokenKey, value: token);
+    }
+  }
+}

--- a/app_store_frontend/pubspec.yaml
+++ b/app_store_frontend/pubspec.yaml
@@ -1,0 +1,29 @@
+name: app_store_frontend
+description: An internal app store for Android and iOS apps.
+publish_to: 'none'
+version: 1.0.0+1
+
+environment:
+  sdk: '>=3.0.0 <4.0.0'
+
+dependencies:
+  flutter:
+    sdk: flutter
+  flutter_riverpod: ^2.3.6
+  dio: ^5.1.1
+  flutter_dotenv: ^5.0.2
+  shared_preferences: ^2.0.15
+  flutter_secure_storage: ^8.0.0
+  file_picker: ^5.2.5
+  url_launcher: ^6.1.10
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+  flutter_lints: ^2.0.0
+
+flutter:
+  uses-material-design: true
+
+  assets:
+    - .env


### PR DESCRIPTION
This commit introduces the initial scaffolding for the Flutter-based frontend of the internal app store.

It includes the following:
- A modular project structure with directories for features, services, and models.
- All required dependencies, including Riverpod, Dio, and flutter_dotenv.
- Basic UI pages for Login, App List, and an Admin Dashboard with an upload form.
- Services for handling API communication and authentication, including a Dio client with a JWT interceptor.
- Environment configuration setup using a .env file for the backend URL.
- A comprehensive README with setup and usage instructions.